### PR TITLE
Add gear equipment system

### DIFF
--- a/gear_system/README.md
+++ b/gear_system/README.md
@@ -1,0 +1,5 @@
+# Gear System
+
+This resource adds a modular equipment system that allows defining existing inventory items as gear which provide player stats when equipped. It supports ESX and QBCore automatically and can optionally integrate with `ox_inventory` for item management.
+
+Use `/gear` to open the equipment panel or configure it to open when the inventory UI opens. Items defined in `config.lua` can be dragged into gear slots and their stats are applied immediately.

--- a/gear_system/client.lua
+++ b/gear_system/client.lua
@@ -1,0 +1,72 @@
+local PlayerData = {}
+local equipped = {}
+
+local function applyStats(stats)
+    -- Example stat application. You can expand this to handle more.
+    if stats.maxHealth then
+        local ped = PlayerPedId()
+        local base = GetEntityMaxHealth(ped)
+        local new = 200 + stats.maxHealth -- default max health is 200
+        if new ~= base then
+            SetEntityMaxHealth(ped, new)
+            if GetEntityHealth(ped) > new then
+                SetEntityHealth(ped, new)
+            end
+        end
+    end
+
+    if stats.maxArmor then
+        local ped = PlayerPedId()
+        SetPedArmour(ped, math.min(100, stats.maxArmor))
+    end
+end
+
+RegisterNetEvent('gear_system:applyStats', function(stats)
+    applyStats(stats)
+end)
+
+RegisterNetEvent('gear_system:setGear', function(data)
+    equipped = data
+    SendNUIMessage({action = 'setGear', gear = data, slots = Config.GearSlots})
+end)
+
+local uiOpen = false
+
+local function toggleUI(state)
+    uiOpen = state
+    SetNuiFocus(state, state)
+    SendNUIMessage({action = state and 'open' or 'close', gear = equipped, slots = Config.GearSlots, pos = Config.PanelPosition})
+end
+
+RegisterNUICallback('equip', function(data, cb)
+    TriggerServerEvent('gear_system:equip', data.slot, data.item)
+    cb(true)
+end)
+
+RegisterNUICallback('unequip', function(data, cb)
+    TriggerServerEvent('gear_system:unequip', data.slot)
+    cb(true)
+end)
+
+RegisterNUICallback('close', function(_, cb)
+    toggleUI(false)
+    cb(true)
+end)
+
+RegisterCommand('gear', function()
+    toggleUI(true)
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res == GetCurrentResourceName() and uiOpen then
+        SetNuiFocus(false, false)
+    end
+end)
+
+RegisterNetEvent('ox_inventory:openInventory', function()
+    toggleUI(true)
+end)
+
+RegisterNetEvent('ox_inventory:closeInventory', function()
+    toggleUI(false)
+end)

--- a/gear_system/config.lua
+++ b/gear_system/config.lua
@@ -1,0 +1,214 @@
+--[[
+==========================================================
+ FiveM Equipment Gear System - Configuration File
+==========================================================
+
+🧩 INSTALLATION INSTRUCTIONS:
+
+1. Place this resource folder in your server's `resources/[standalone]/` directory.
+2. Ensure the following lines are in your `server.cfg`:
+
+    ensure ox_lib
+    ensure ox_inventory
+    ensure gear_system
+
+3. If using ESX or QBCore, make sure it's properly set up before using this script.
+
+4. This config file allows you to fully customize:
+    - What items can be equipped
+    - What gear slots exist
+    - What stat bonuses gear items give
+    - How stats are scaled
+    - UI behavior and slot rules
+
+You DO NOT need to know Lua to use this script. Just follow the examples and comments.
+==========================================================
+]]
+
+Config = {}
+
+--///////////////////////////////////////////////////////////////
+-- General Settings
+--///////////////////////////////////////////////////////////////
+
+-- Framework selection:
+--  "auto"   - automatically detect ESX or QBCore
+--  "esx"    - force ESX
+--  "qbcore" - force QBCore
+Config.Framework = 'auto'
+
+-- Set to true if you use ox_inventory so gear items are added/removed using
+-- the ox_inventory exports. Set to false to use the framework's inventory.
+Config.UseOxInventory = true
+
+-- Enable to print debug information to the server/clientside consoles.
+Config.Debug = false
+
+-- Position of the equipment panel on screen (in pixels).
+Config.PanelPosition = {
+    top = 200,   -- distance from top of the screen
+    left = 50    -- distance from left of the screen
+}
+
+--///////////////////////////////////////////////////////////////
+-- Gear Slot Definitions
+--///////////////////////////////////////////////////////////////
+-- Each slot represents a place where the player can equip an item.
+--  label        : Text shown in the UI for this slot.
+--  allowMultiple: If true, this slot could accept multiple items (not used by
+--                  the basic script but kept for future expansion).
+--  showInUI     : Should this slot appear in the drag-and-drop panel?
+Config.GearSlots = {
+    helmet = {
+        label = 'Helmet',
+        allowMultiple = false,
+        showInUI = true
+    },
+    chest = {
+        label = 'Body Armor',
+        allowMultiple = false,
+        showInUI = true
+    },
+    pants = {
+        label = 'Pants',
+        allowMultiple = false,
+        showInUI = true
+    },
+    gloves = {
+        label = 'Gloves',
+        allowMultiple = false,
+        showInUI = true
+    },
+    boots = {
+        label = 'Boots',
+        allowMultiple = false,
+        showInUI = true
+    },
+    ring1 = {
+        label = 'Ring (L)',
+        allowMultiple = false,
+        showInUI = true
+    },
+    ring2 = {
+        label = 'Ring (R)',
+        allowMultiple = false,
+        showInUI = true
+    },
+    backpack = {
+        label = 'Backpack',
+        allowMultiple = false,
+        showInUI = true
+    },
+    weaponmod = {
+        label = 'Weapon Mod',
+        allowMultiple = false,
+        showInUI = true
+    }
+}
+
+--///////////////////////////////////////////////////////////////
+-- Equipment Item Definitions
+--///////////////////////////////////////////////////////////////
+-- Each entry links an existing inventory item to a gear slot and describes
+-- the stat bonuses it grants when equipped.
+--  slot  : Which gear slot this item can occupy.
+--  label : Friendly name shown in the UI when equipped.
+--  stats : Table of stat bonuses. Each stat has:
+--          type  - "flat" for a direct value, or "percent" for a multiplier.
+--          value - Number applied to the player when this gear is equipped.
+Config.EquipmentItems = {
+    -- Helmet that increases health and crit chance
+    military_helmet = {
+        slot = 'helmet',
+        label = 'Military Helmet',
+        stats = {
+            maxHealth = { type = 'flat', value = 25 },
+            critChance = { type = 'percent', value = 0.10 }
+        }
+    },
+
+    -- Heavy kevlar vest providing additional armour
+    kevlar_vest = {
+        slot = 'chest',
+        label = 'Kevlar Vest',
+        stats = {
+            maxArmor = { type = 'flat', value = 50 }
+        }
+    },
+
+    -- Ring that boosts damage and stamina recovery
+    ring_of_fire = {
+        slot = 'ring1',
+        label = 'Ring of Fire',
+        stats = {
+            damagePercent = { type = 'percent', value = 0.15 },
+            staminaRecovery = { type = 'flat', value = 5 }
+        }
+    },
+
+    -- Gloves increasing flat damage and critical damage
+    gloves_of_fury = {
+        slot = 'gloves',
+        label = 'Gloves of Fury',
+        stats = {
+            flatDamage = { type = 'flat', value = 5 },
+            critDamage = { type = 'percent', value = 0.20 }
+        }
+    },
+
+    -- Boots that slightly slow you but improve melee damage
+    iron_boots = {
+        slot = 'boots',
+        label = 'Iron Boots',
+        stats = {
+            speedPercent = { type = 'percent', value = -0.05 },
+            meleeDamage = { type = 'percent', value = 0.10 }
+        }
+    },
+
+    -- Backpack that increases total stamina
+    endurance_pack = {
+        slot = 'backpack',
+        label = 'Endurance Pack',
+        stats = {
+            maxStamina = { type = 'flat', value = 20 }
+        }
+    }
+}
+
+--///////////////////////////////////////////////////////////////
+-- Stat Scaling
+--///////////////////////////////////////////////////////////////
+-- These multipliers allow you to tweak the overall strength of each stat
+-- without editing every item individually. Most servers will leave these at 1.
+--  maxHealth       (flat)    Adds directly to the player's maximum health.
+--  maxArmor        (flat)    Adds directly to the player's armour points.
+--  critChance      (percent) Adds to the player's critical hit chance.
+--  critDamage      (percent) Multiplies damage dealt on a critical hit.
+--  flatDamage      (flat)    Additional damage added to every attack.
+--  damagePercent   (percent) Multiplier applied to all damage dealt.
+--  speedPercent    (percent) Percentage increase or decrease to running speed.
+--  staminaRecovery (flat)    Extra stamina regenerated per second.
+--  maxStamina      (flat)    Adds to the player's total stamina pool.
+--  meleeDamage     (percent) Multiplier for unarmed/melee damage.
+Config.StatScaling = {
+    maxHealth = 1.0,
+    maxArmor = 1.0,
+    critChance = 1.0,
+    critDamage = 1.0,
+    flatDamage = 1.0,
+    damagePercent = 1.0,
+    speedPercent = 1.0,
+    staminaRecovery = 1.0,
+    maxStamina = 1.0,
+    meleeDamage = 1.0
+}
+
+--///////////////////////////////////////////////////////////////
+-- Utility debug function used internally
+--///////////////////////////////////////////////////////////////
+function Debug(...)
+    if Config.Debug then
+        print('[GearSystem]', ...)
+    end
+end

--- a/gear_system/fxmanifest.lua
+++ b/gear_system/fxmanifest.lua
@@ -1,0 +1,26 @@
+fx_version 'cerulean'
+lua54 'yes'
+game 'gta5'
+
+name 'gear_system'
+author 'Generated'
+
+ui_page 'ui/index.html'
+
+files {
+    'ui/index.html',
+    'ui/style.css',
+    'ui/script.js'
+}
+
+shared_scripts {
+    'config.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}

--- a/gear_system/server.lua
+++ b/gear_system/server.lua
@@ -1,0 +1,192 @@
+local GearData = {}
+local PlayerStats = {}
+local framework = {}
+
+local function loadData()
+    local data = LoadResourceFile(GetCurrentResourceName(), 'gear_data.json')
+    if data then
+        GearData = json.decode(data)
+    end
+end
+
+local function saveData()
+    SaveResourceFile(GetCurrentResourceName(), 'gear_data.json', json.encode(GearData), -1)
+end
+
+local function detectFramework()
+    if Config.Framework ~= 'auto' then return Config.Framework end
+    if GetResourceState('es_extended') ~= 'missing' then return 'esx' end
+    if GetResourceState('qb-core') ~= 'missing' then return 'qbcore' end
+    return nil
+end
+
+local function initFramework()
+    framework.name = detectFramework()
+    if framework.name == 'esx' then
+        framework.obj = exports['es_extended']:getSharedObject()
+        framework.getPlayer = function(src) return framework.obj.GetPlayerFromId(src) end
+        framework.identifier = function(player) return player.identifier end
+        framework.addItem = function(player, name)
+            player.addInventoryItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.getInventoryItem(name)
+            if item.count < 1 then return false end
+            player.removeInventoryItem(name, 1)
+            return true
+        end
+    elseif framework.name == 'qbcore' then
+        framework.obj = exports['qb-core']:GetCoreObject()
+        framework.getPlayer = function(src) return framework.obj.Functions.GetPlayer(src) end
+        framework.identifier = function(player) return player.PlayerData.citizenid end
+        framework.addItem = function(player, name)
+            player.Functions.AddItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.Functions.GetItemByName(name)
+            if not item or item.amount < 1 then return false end
+            player.Functions.RemoveItem(name, 1)
+            return true
+        end
+    end
+end
+
+local function getIdentifier(src)
+    local player = framework.getPlayer(src)
+    if not player then return nil end
+    return framework.identifier(player)
+end
+
+local function giveItem(src, name)
+    if Config.UseOxInventory then
+        exports.ox_inventory:AddItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then framework.addItem(player, name) end
+    end
+end
+
+local function takeItem(src, name)
+    if Config.UseOxInventory then
+        return exports.ox_inventory:RemoveItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then
+            return framework.removeItem(player, name)
+        end
+    end
+    return false
+end
+
+local function calculateStats(equipped)
+    local stats = {}
+    for slot, item in pairs(equipped) do
+        local cfg = Config.EquipmentItems[item]
+        if cfg and cfg.stats then
+            for stat, info in pairs(cfg.stats) do
+                local value = info.value or 0
+                stats[stat] = (stats[stat] or 0) + (value * (Config.StatScaling[stat] or 1))
+            end
+        else
+            Debug('Unknown equipment item in slot', slot, item)
+        end
+    end
+    return stats
+end
+
+local function updatePlayerStats(src)
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local equipped = GearData[identifier] or {}
+    local stats = calculateStats(equipped)
+    PlayerStats[src] = stats
+    TriggerClientEvent('gear_system:applyStats', src, stats)
+    -- convert equipped items to their display labels for the UI
+    local display = {}
+    for slot, item in pairs(equipped) do
+        local cfg = Config.EquipmentItems[item]
+        display[slot] = cfg and cfg.label or item
+    end
+    TriggerClientEvent('gear_system:setGear', src, display)
+    TriggerEvent('gear_system:statsUpdated', src, stats)
+end
+
+RegisterNetEvent('gear_system:equip', function(slot, item)
+    local src = source
+    if not Config.GearSlots[slot] then return end
+    if not item then return end
+
+    local cfg = Config.EquipmentItems[item]
+    if not cfg then
+        Debug('Tried to equip unknown item', item)
+        return
+    end
+    if cfg.slot ~= slot then
+        Debug('Item', item, 'cannot be equipped in slot', slot)
+        return
+    end
+
+    if not takeItem(src, item) then return end
+
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+    GearData[identifier] = GearData[identifier] or {}
+
+    local old = GearData[identifier][slot]
+    if old then
+        giveItem(src, old)
+    end
+
+    GearData[identifier][slot] = item
+    saveData()
+    updatePlayerStats(src)
+end)
+
+RegisterNetEvent('gear_system:unequip', function(slot)
+    local src = source
+    if not Config.GearSlots[slot] then return end
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local item = GearData[identifier] and GearData[identifier][slot]
+    if item then
+        giveItem(src, item)
+        GearData[identifier][slot] = nil
+        saveData()
+        updatePlayerStats(src)
+    end
+end)
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    PlayerStats[src] = nil
+end)
+
+exports('GetPlayerStats', function(src)
+    return PlayerStats[src] or {}
+end)
+
+AddEventHandler('onResourceStart', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    initFramework()
+    loadData()
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    saveData()
+end)
+
+-- framework player loaded events
+RegisterNetEvent('esx:playerLoaded', function(id)
+    if framework.name ~= 'esx' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)
+
+RegisterNetEvent('QBCore:Server:PlayerLoaded', function(id)
+    if framework.name ~= 'qbcore' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)

--- a/gear_system/ui/index.html
+++ b/gear_system/ui/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Gear System</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div id="gear-panel" class="hidden">
+    <div id="close">X</div>
+    <div id="slots"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/gear_system/ui/script.js
+++ b/gear_system/ui/script.js
@@ -1,0 +1,84 @@
+let gear = {};
+let slots = {};
+
+function createSlots() {
+    const container = document.getElementById('slots');
+    container.innerHTML = '';
+    Object.entries(slots).forEach(([name, cfg]) => {
+        if (!cfg.showInUI) return;
+        const div = document.createElement('div');
+        div.className = 'slot';
+        div.dataset.slot = name;
+        div.textContent = cfg.label;
+        div.addEventListener('dragover', e => {
+            e.preventDefault();
+            div.classList.add('dragover');
+        });
+        div.addEventListener('dragleave', () => div.classList.remove('dragover'));
+        div.addEventListener('drop', e => {
+            e.preventDefault();
+            div.classList.remove('dragover');
+            const item = e.dataTransfer.getData('item');
+            if (item) sendEquip(name, item);
+        });
+        container.appendChild(div);
+    });
+}
+
+function renderGear() {
+    document.querySelectorAll('.slot').forEach(s => {
+        const slot = s.dataset.slot;
+        s.innerHTML = `<strong>${slots[slot].label}</strong>`;
+        const item = gear[slot];
+        if (item) {
+            const el = document.createElement('div');
+            el.className = 'item';
+            el.textContent = item;
+            el.draggable = true;
+            el.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('slot', slot);
+                e.dataTransfer.setData('item', item);
+            });
+            s.appendChild(el);
+        }
+    });
+}
+
+function sendEquip(slot, item) {
+    fetch(`https://gear_system/equip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot, item})
+    });
+}
+
+function sendUnequip(slot) {
+    fetch(`https://gear_system/unequip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot})
+    });
+}
+
+document.getElementById('close').addEventListener('click', () => {
+    fetch('https://gear_system/close', {method: 'POST'});
+});
+
+window.addEventListener('message', event => {
+    const data = event.data;
+    if (data.action === 'open') {
+        gear = data.gear || {};
+        slots = data.slots || {};
+        createSlots();
+        renderGear();
+        const panel = document.getElementById('gear-panel');
+        panel.style.top = data.pos.top + 'px';
+        panel.style.left = data.pos.left + 'px';
+        panel.classList.add('show');
+    } else if (data.action === 'close') {
+        document.getElementById('gear-panel').classList.remove('show');
+    } else if (data.action === 'setGear') {
+        gear = data.gear || {};
+        renderGear();
+    }
+});

--- a/gear_system/ui/style.css
+++ b/gear_system/ui/style.css
@@ -1,0 +1,35 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+#gear-panel {
+    position: absolute;
+    background: rgba(30, 30, 30, 0.9);
+    padding: 10px;
+    width: 200px;
+    color: #fff;
+    display: none;
+}
+#gear-panel.show {
+    display: block;
+}
+#close {
+    cursor: pointer;
+    text-align: right;
+}
+.slot {
+    border: 1px solid #555;
+    padding: 5px;
+    margin: 5px 0;
+    background: #222;
+    min-height: 30px;
+}
+.slot.dragover {
+    background: #444;
+}
+.item {
+    background: #555;
+    margin: 2px;
+    padding: 2px 4px;
+    cursor: move;
+}


### PR DESCRIPTION
## Summary
- add a standalone `gear_system` resource
- implement ESX/QBCore framework detection
- provide drag-and-drop equipment UI and stat bonuses
- sample configuration with example items
- rewrite config and update gear logic

## Testing
- `git status --short`