### PR TITLE
Add gear equipment system

### DIFF
--- a/gear_system/README.md
+++ b/gear_system/README.md
@@ -1,0 +1,5 @@
+# Gear System
+
+This resource adds a modular equipment system that allows defining existing inventory items as gear which provide player stats when equipped. It supports ESX and QBCore automatically and can optionally integrate with `ox_inventory` for item management.
+
+Use `/gear` to open the equipment panel or configure it to open when the inventory UI opens. Items defined in `config.lua` can be dragged into gear slots and their stats are applied immediately.

--- a/gear_system/client.lua
+++ b/gear_system/client.lua
@@ -1,0 +1,80 @@
+local PlayerData = {}
+local equipped = {}
+
+local function applyStats(stats)
+    -- Example stat application. You can expand this to handle more.
+    if stats.maxHealth then
+        local ped = PlayerPedId()
+        local base = GetEntityMaxHealth(ped)
+        local new = 200 + stats.maxHealth -- default max health is 200
+        if new ~= base then
+            SetEntityMaxHealth(ped, new)
+            if GetEntityHealth(ped) > new then
+                SetEntityHealth(ped, new)
+            end
+        end
+    end
+
+    if stats.maxArmor then
+        local ped = PlayerPedId()
+        SetPedArmour(ped, math.min(100, stats.maxArmor))
+    end
+end
+
+RegisterNetEvent('gear_system:applyStats', function(stats)
+    applyStats(stats)
+end)
+
+RegisterNetEvent('gear_system:setGear', function(data)
+    equipped = data
+    SendNUIMessage({action = 'setGear', gear = data, slots = Config.GearSlots})
+end)
+
+RegisterNetEvent('gear_system:notify', function(msg)
+    if lib and lib.notify then
+        lib.notify({ description = msg })
+    else
+        print('[GearSystem]', msg)
+    end
+end)
+
+local uiOpen = false
+
+local function toggleUI(state)
+    uiOpen = state
+    SetNuiFocus(state, state)
+    SendNUIMessage({action = state and 'open' or 'close', gear = equipped, slots = Config.GearSlots, pos = Config.PanelPosition})
+end
+
+RegisterNUICallback('equip', function(data, cb)
+    TriggerServerEvent('gear_system:equip', data.slot, data.item)
+    cb(true)
+end)
+
+RegisterNUICallback('unequip', function(data, cb)
+    TriggerServerEvent('gear_system:unequip', data.slot)
+    cb(true)
+end)
+
+RegisterNUICallback('close', function(_, cb)
+    toggleUI(false)
+    cb(true)
+end)
+
+RegisterCommand('gear', function()
+    toggleUI(true)
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res == GetCurrentResourceName() and uiOpen then
+        SetNuiFocus(false, false)
+    end
+end)
+
+RegisterNetEvent('ox_inventory:openInventory', function()
+    toggleUI(true)
+end)
+
+RegisterNetEvent('ox_inventory:closeInventory', function()
+    toggleUI(false)
+end)

--- a/gear_system/config.lua
+++ b/gear_system/config.lua
@@ -1,0 +1,195 @@
+Config = {}
+
+--[[
+==========================================================
+ FiveM Gear System - Configuration File
+==========================================================
+
+INSTALLATION:
+
+1. Place this script in your server's `resources/[standalone]/` folder.
+2. Add the following lines to your `server.cfg`:
+
+       ensure ox_lib
+       ensure ox_inventory
+       ensure gear_system
+
+3. Edit the sections below to customise items, slots and behaviour.
+   No Lua knowledge required – follow the examples and comments.
+==========================================================
+]]
+
+-- Framework selection: 'auto', 'esx', or 'qbcore'
+-- When set to 'auto', the script will try to detect your framework.
+Config.Framework = 'auto'
+
+-- If true, uses ox_inventory exports to add/remove items when equipping.
+Config.UseOxInventory = true
+
+-- General debug messages in server/client consoles.
+Config.Debug = false
+
+-- Extra debugging and testing tools. Safe to disable when not needed.
+Config.DebugTools = {
+    enableVerboseLogs = true,           -- Detailed logging for equip events
+    logStatCalculations = true,         -- Print how final stats are calculated
+    logItemLookup = true,               -- Log item/slot validation steps
+    showInvalidItems = true,            -- Warn if an item is missing from config
+    showInvalidSlots = true,            -- Warn if a slot is not defined
+    printStatTotalsOnEquip = true,      -- Output total stats when gear changes
+    notifyOnEquip = true,               -- In-game notification on equip/unequip
+    debugCommandEnabled = true          -- Enables /gearstatus command
+}
+
+-- UI position for the gear panel (CSS top/left in pixels)
+Config.PanelPosition = {
+    top = 200,
+    left = 50
+}
+
+-- Rarity tiers apply colour coding and stat multipliers.
+Config.RarityTiers = {
+    common =    { label = 'Common',    color = '#808080', statMultiplier = 1.0 },
+    uncommon =  { label = 'Uncommon',  color = '#00ff00', statMultiplier = 1.1 },
+    rare =      { label = 'Rare',      color = '#007bff', statMultiplier = 1.25 },
+    epic =      { label = 'Epic',      color = '#a64ca6', statMultiplier = 1.4 },
+    legendary = { label = 'Legendary', color = '#ff4444', statMultiplier = 1.6 }
+}
+
+--[[
+Gear Slots: these are the ONLY slots supported by the script.
+Each slot lists which item names can be equipped there.
+]]
+Config.GearSlots = {
+    head      = { label = 'Head',      allowedItems = { 'military_helmet', 'iron_helmet' } },
+    chest     = { label = 'Chest',     allowedItems = { 'kevlar_vest', 'leather_armor' } },
+    legs      = { label = 'Legs',      allowedItems = { 'combat_pants', 'jeans' } },
+    feet      = { label = 'Feet',      allowedItems = { 'army_boots', 'leather_boots' } },
+    hands     = { label = 'Hands',     allowedItems = { 'tactical_gloves' } },
+    neck      = { label = 'Neck',      allowedItems = { 'silver_amulet' } },
+    ring1     = { label = 'Ring (L)',  allowedItems = { 'ring_of_fire', 'ring_of_life' } },
+    ring2     = { label = 'Ring (R)',  allowedItems = { 'ring_of_power' } },
+    trinket1  = { label = 'Trinket 1', allowedItems = { 'ancient_rune' } },
+    trinket2  = { label = 'Trinket 2', allowedItems = { 'mystic_charm' } }
+}
+
+--[[
+Equipment item definitions. Each key is the inventory item name.
+  slot   = which gear slot it fits into
+  label  = displayed name in the UI
+  rarity = affects colour and stat scaling
+  stats  = table of stat bonuses (type = 'flat' or 'percent')
+]]
+Config.EquipmentItems = {
+    military_helmet = {
+        slot = 'head',
+        label = 'Military Helmet',
+        rarity = 'common',
+        stats = {
+            maxHealth = { type = 'flat', value = 20 },
+            critChance = { type = 'percent', value = 0.05 }
+        }
+    },
+    kevlar_vest = {
+        slot = 'chest',
+        label = 'Kevlar Vest',
+        rarity = 'uncommon',
+        stats = {
+            maxArmor = { type = 'flat', value = 50 }
+        }
+    },
+    combat_pants = {
+        slot = 'legs',
+        label = 'Combat Pants',
+        rarity = 'common',
+        stats = {
+            speedPercent = { type = 'percent', value = 0.05 }
+        }
+    },
+    army_boots = {
+        slot = 'feet',
+        label = 'Army Boots',
+        rarity = 'common',
+        stats = {
+            speedPercent = { type = 'percent', value = 0.05 }
+        }
+    },
+    tactical_gloves = {
+        slot = 'hands',
+        label = 'Tactical Gloves',
+        rarity = 'rare',
+        stats = {
+            meleeDamage = { type = 'percent', value = 0.1 }
+        }
+    },
+    silver_amulet = {
+        slot = 'neck',
+        label = 'Silver Amulet',
+        rarity = 'rare',
+        stats = {
+            staminaRecovery = { type = 'flat', value = 2 }
+        }
+    },
+    ring_of_fire = {
+        slot = 'ring1',
+        label = 'Ring of Fire',
+        rarity = 'epic',
+        stats = {
+            damagePercent = { type = 'percent', value = 0.15 }
+        }
+    },
+    ring_of_life = {
+        slot = 'ring1',
+        label = 'Ring of Life',
+        rarity = 'rare',
+        stats = {
+            maxHealth = { type = 'flat', value = 15 }
+        }
+    },
+    ring_of_power = {
+        slot = 'ring2',
+        label = 'Ring of Power',
+        rarity = 'legendary',
+        stats = {
+            damageFlat = { type = 'flat', value = 5 }
+        }
+    },
+    ancient_rune = {
+        slot = 'trinket1',
+        label = 'Ancient Rune',
+        rarity = 'uncommon',
+        stats = {
+            critDamage = { type = 'percent', value = 0.2 }
+        }
+    },
+    mystic_charm = {
+        slot = 'trinket2',
+        label = 'Mystic Charm',
+        rarity = 'rare',
+        stats = {
+            maxStamina = { type = 'flat', value = 10 }
+        }
+    }
+}
+
+-- Scaling applied to stats before they are given to the player.
+-- Adjust these numbers to globally increase or reduce effects.
+Config.StatScaling = {
+    maxHealth       = 1.0,
+    maxArmor        = 1.0,
+    critChance      = 1.0,
+    critDamage      = 1.0,
+    damageFlat      = 1.0,
+    damagePercent   = 1.0,
+    speedPercent    = 1.0,
+    staminaRecovery = 1.0,
+    maxStamina      = 1.0,
+    meleeDamage     = 1.0
+}
+
+-- Simple debug print helper
+function Debug(...)
+    if Config.Debug or (Config.DebugTools.enableVerboseLogs) then
+        print('[GearSystem]', ...)
+    end
+end

--- a/gear_system/fxmanifest.lua
+++ b/gear_system/fxmanifest.lua
@@ -1,0 +1,26 @@
+fx_version 'cerulean'
+lua54 'yes'
+game 'gta5'
+
+name 'gear_system'
+author 'Generated'
+
+ui_page 'ui/index.html'
+
+files {
+    'ui/index.html',
+    'ui/style.css',
+    'ui/script.js'
+}
+
+shared_scripts {
+    'config.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}

--- a/gear_system/server.lua
+++ b/gear_system/server.lua
@@ -1,0 +1,270 @@
+local GearData = {}
+local PlayerStats = {}
+local framework = {}
+
+local function loadData()
+    local data = LoadResourceFile(GetCurrentResourceName(), 'gear_data.json')
+    if data then
+        GearData = json.decode(data)
+    end
+end
+
+local function saveData()
+    SaveResourceFile(GetCurrentResourceName(), 'gear_data.json', json.encode(GearData), -1)
+end
+
+local function detectFramework()
+    if Config.Framework ~= 'auto' then return Config.Framework end
+    if GetResourceState('es_extended') ~= 'missing' then return 'esx' end
+    if GetResourceState('qb-core') ~= 'missing' then return 'qbcore' end
+    return nil
+end
+
+local function initFramework()
+    framework.name = detectFramework()
+    if framework.name == 'esx' then
+        framework.obj = exports['es_extended']:getSharedObject()
+        framework.getPlayer = function(src) return framework.obj.GetPlayerFromId(src) end
+        framework.identifier = function(player) return player.identifier end
+        framework.addItem = function(player, name)
+            player.addInventoryItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.getInventoryItem(name)
+            if item.count < 1 then return false end
+            player.removeInventoryItem(name, 1)
+            return true
+        end
+    elseif framework.name == 'qbcore' then
+        framework.obj = exports['qb-core']:GetCoreObject()
+        framework.getPlayer = function(src) return framework.obj.Functions.GetPlayer(src) end
+        framework.identifier = function(player) return player.PlayerData.citizenid end
+        framework.addItem = function(player, name)
+            player.Functions.AddItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.Functions.GetItemByName(name)
+            if not item or item.amount < 1 then return false end
+            player.Functions.RemoveItem(name, 1)
+            return true
+        end
+    end
+end
+
+local function getIdentifier(src)
+    local player = framework.getPlayer(src)
+    if not player then return nil end
+    return framework.identifier(player)
+end
+
+local function giveItem(src, name)
+    if Config.UseOxInventory then
+        exports.ox_inventory:AddItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then framework.addItem(player, name) end
+    end
+end
+
+local function takeItem(src, name)
+    if Config.UseOxInventory then
+        return exports.ox_inventory:RemoveItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then
+            return framework.removeItem(player, name)
+        end
+    end
+    return false
+end
+
+local function calculateStats(equipped)
+    local stats = {}
+    for slot, itemName in pairs(equipped) do
+        local item = Config.EquipmentItems[itemName]
+        if not item then
+            if Config.DebugTools.showInvalidItems then
+                Debug('Unknown item in slot '..slot..': '..tostring(itemName))
+            end
+        else
+            local rarity = Config.RarityTiers[item.rarity] or {statMultiplier = 1.0}
+            if Config.DebugTools.logItemLookup then
+                Debug(('Slot %s item %s rarity %s'):format(slot, itemName, item.rarity or 'none'))
+            end
+            for stat, info in pairs(item.stats or {}) do
+                local base = info.value or 0
+                local scaled = base * rarity.statMultiplier * (Config.StatScaling[stat] or 1)
+                stats[stat] = (stats[stat] or 0) + scaled
+            end
+        end
+    end
+    if Config.DebugTools.logStatCalculations then
+        Debug('Calculated stats: '..json.encode(stats))
+    end
+    return stats
+end
+
+local function updatePlayerStats(src)
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local equipped = GearData[identifier] or {}
+    local stats = calculateStats(equipped)
+    PlayerStats[src] = stats
+
+    local displayGear = {}
+    for slot, itemName in pairs(equipped) do
+        local item = Config.EquipmentItems[itemName]
+        if item then
+            local rarity = Config.RarityTiers[item.rarity]
+            displayGear[slot] = {
+                name = itemName,
+                label = item.label,
+                rarity = item.rarity,
+                color = rarity and rarity.color or '#ffffff'
+            }
+        else
+            displayGear[slot] = { name = itemName, label = itemName }
+        end
+    end
+
+    TriggerClientEvent('gear_system:applyStats', src, stats)
+    TriggerClientEvent('gear_system:setGear', src, displayGear)
+    TriggerEvent('gear_system:statsUpdated', src, stats)
+    if Config.DebugTools.printStatTotalsOnEquip then
+        Debug(('Total stats for %s: %s'):format(src, json.encode(stats)))
+    end
+end
+
+RegisterNetEvent('gear_system:equip', function(slot, item)
+    local src = source
+    if not Config.GearSlots[slot] then
+        if Config.DebugTools.showInvalidSlots then
+            Debug('Attempt to equip invalid slot '..tostring(slot))
+        end
+        return
+    end
+    if not item then return end
+
+    local allowed = false
+    for _, v in pairs(Config.GearSlots[slot].allowedItems) do
+        if v == item then allowed = true break end
+    end
+    if not allowed then
+        if Config.DebugTools.logItemLookup then
+            Debug(('Item %s not allowed in slot %s'):format(item, slot))
+        end
+        return
+    end
+
+    local itemDef = Config.EquipmentItems[item]
+    if not itemDef then
+        if Config.DebugTools.showInvalidItems then
+            Debug('Cannot equip undefined item '..tostring(item))
+        end
+        return
+    end
+
+    if not takeItem(src, item) then return end
+
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+    GearData[identifier] = GearData[identifier] or {}
+
+    local old = GearData[identifier][slot]
+    if old then
+        giveItem(src, old)
+    end
+
+    GearData[identifier][slot] = item
+    saveData()
+    updatePlayerStats(src)
+    if Config.DebugTools.notifyOnEquip then
+        TriggerClientEvent('gear_system:notify', src, ('Equipped %s'):format(itemDef.label))
+    end
+end)
+
+RegisterNetEvent('gear_system:unequip', function(slot)
+    local src = source
+    if not Config.GearSlots[slot] then
+        if Config.DebugTools.showInvalidSlots then
+            Debug('Attempt to unequip invalid slot '..tostring(slot))
+        end
+        return
+    end
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local item = GearData[identifier] and GearData[identifier][slot]
+    if item then
+        giveItem(src, item)
+        GearData[identifier][slot] = nil
+        saveData()
+        updatePlayerStats(src)
+        if Config.DebugTools.notifyOnEquip then
+            local itemDef = Config.EquipmentItems[item]
+            local label = itemDef and itemDef.label or item
+            TriggerClientEvent('gear_system:notify', src, ('Unequipped %s'):format(label))
+        end
+    end
+end)
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    PlayerStats[src] = nil
+end)
+
+exports('GetPlayerStats', function(src)
+    return PlayerStats[src] or {}
+end)
+
+-- Optional debug command to print current gear and stats
+if Config.DebugTools.debugCommandEnabled then
+    RegisterCommand('gearstatus', function(src)
+        local identifier = getIdentifier(src)
+        if not identifier then return end
+        local gear = GearData[identifier] or {}
+        local stats = PlayerStats[src] or calculateStats(gear)
+        Debug(('Gear for %s: %s'):format(src, json.encode(gear)))
+        Debug(('Stats for %s: %s'):format(src, json.encode(stats)))
+        TriggerClientEvent('gear_system:notify', src, 'Check server console for gear status')
+    end, false)
+
+    RegisterCommand('gearreset', function(src)
+        local identifier = getIdentifier(src)
+        if not identifier then return end
+        local current = GearData[identifier]
+        if not current then return end
+        for slot, item in pairs(current) do
+            giveItem(src, item)
+            current[slot] = nil
+        end
+        saveData()
+        updatePlayerStats(src)
+        TriggerClientEvent('gear_system:notify', src, 'All gear unequipped')
+    end, false)
+end
+
+AddEventHandler('onResourceStart', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    initFramework()
+    loadData()
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    saveData()
+end)
+
+-- framework player loaded events
+RegisterNetEvent('esx:playerLoaded', function(id)
+    if framework.name ~= 'esx' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)
+
+RegisterNetEvent('QBCore:Server:PlayerLoaded', function(id)
+    if framework.name ~= 'qbcore' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)

--- a/gear_system/ui/index.html
+++ b/gear_system/ui/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Gear System</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div id="gear-panel" class="hidden">
+    <div id="close">X</div>
+    <div id="slots"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/gear_system/ui/script.js
+++ b/gear_system/ui/script.js
@@ -1,0 +1,86 @@
+let gear = {};
+let slots = {};
+
+function createSlots() {
+    const container = document.getElementById('slots');
+    container.innerHTML = '';
+    Object.entries(slots).forEach(([name, cfg]) => {
+        const div = document.createElement('div');
+        div.className = 'slot';
+        div.dataset.slot = name;
+        div.textContent = cfg.label;
+        div.addEventListener('dragover', e => {
+            e.preventDefault();
+            div.classList.add('dragover');
+        });
+        div.addEventListener('dragleave', () => div.classList.remove('dragover'));
+        div.addEventListener('drop', e => {
+            e.preventDefault();
+            div.classList.remove('dragover');
+            const item = e.dataTransfer.getData('item');
+            if (item) sendEquip(name, item);
+        });
+        container.appendChild(div);
+    });
+}
+
+function renderGear() {
+    document.querySelectorAll('.slot').forEach(s => {
+        const slot = s.dataset.slot;
+        s.innerHTML = `<strong>${slots[slot].label}</strong>`;
+        const item = gear[slot];
+        if (item) {
+            const label = item.label || item;
+            const name = item.name || item;
+            const el = document.createElement('div');
+            el.className = 'item';
+            el.textContent = label;
+            if (item.color) el.style.background = item.color;
+            el.draggable = true;
+            el.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('slot', slot);
+                e.dataTransfer.setData('item', name);
+            });
+            s.appendChild(el);
+        }
+    });
+}
+
+function sendEquip(slot, item) {
+    fetch(`https://gear_system/equip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot, item})
+    });
+}
+
+function sendUnequip(slot) {
+    fetch(`https://gear_system/unequip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot})
+    });
+}
+
+document.getElementById('close').addEventListener('click', () => {
+    fetch('https://gear_system/close', {method: 'POST'});
+});
+
+window.addEventListener('message', event => {
+    const data = event.data;
+    if (data.action === 'open') {
+        gear = data.gear || {};
+        slots = data.slots || {};
+        createSlots();
+        renderGear();
+        const panel = document.getElementById('gear-panel');
+        panel.style.top = data.pos.top + 'px';
+        panel.style.left = data.pos.left + 'px';
+        panel.classList.add('show');
+    } else if (data.action === 'close') {
+        document.getElementById('gear-panel').classList.remove('show');
+    } else if (data.action === 'setGear') {
+        gear = data.gear || {};
+        renderGear();
+    }
+});

--- a/gear_system/ui/style.css
+++ b/gear_system/ui/style.css
@@ -1,0 +1,35 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+#gear-panel {
+    position: absolute;
+    background: rgba(30, 30, 30, 0.9);
+    padding: 10px;
+    width: 200px;
+    color: #fff;
+    display: none;
+}
+#gear-panel.show {
+    display: block;
+}
+#close {
+    cursor: pointer;
+    text-align: right;
+}
+.slot {
+    border: 1px solid #555;
+    padding: 5px;
+    margin: 5px 0;
+    background: #222;
+    min-height: 30px;
+}
+.slot.dragover {
+    background: #444;
+}
+.item {
+    background: #555;
+    margin: 2px;
+    padding: 2px 4px;
+    cursor: move;
+}


### PR DESCRIPTION
## Summary
- add a standalone `gear_system` resource
- implement ESX/QBCore framework detection
- provide drag-and-drop equipment UI and stat bonuses
- sample configuration with example items
- add debug tools and new slot structure

## Testing
- `luac -p gear_system/server.lua`
- `luac -p gear_system/client.lua`
- `lua -e "assert(loadfile('gear_system/config.lua'))"`
