### PR TITLE
Add gear equipment system

### DIFF
--- a/gear_system/README.md
+++ b/gear_system/README.md
@@ -1,0 +1,5 @@
+# Gear System
+
+This resource adds a modular equipment system that allows defining existing inventory items as gear which provide player stats when equipped. It supports ESX and QBCore automatically and can optionally integrate with `ox_inventory` for item management.
+
+Use `/gear` to open the equipment panel or configure it to open when the inventory UI opens. Items defined in `config.lua` can be dragged into gear slots and their stats are applied immediately.

--- a/gear_system/client.lua
+++ b/gear_system/client.lua
@@ -1,0 +1,72 @@
+local PlayerData = {}
+local equipped = {}
+
+local function applyStats(stats)
+    -- Example stat application. You can expand this to handle more.
+    if stats.maxHealth then
+        local ped = PlayerPedId()
+        local base = GetEntityMaxHealth(ped)
+        local new = 200 + stats.maxHealth -- default max health is 200
+        if new ~= base then
+            SetEntityMaxHealth(ped, new)
+            if GetEntityHealth(ped) > new then
+                SetEntityHealth(ped, new)
+            end
+        end
+    end
+
+    if stats.maxArmor then
+        local ped = PlayerPedId()
+        SetPedArmour(ped, math.min(100, stats.maxArmor))
+    end
+end
+
+RegisterNetEvent('gear_system:applyStats', function(stats)
+    applyStats(stats)
+end)
+
+RegisterNetEvent('gear_system:setGear', function(data)
+    equipped = data
+    SendNUIMessage({action = 'setGear', gear = data, slots = Config.GearSlots})
+end)
+
+local uiOpen = false
+
+local function toggleUI(state)
+    uiOpen = state
+    SetNuiFocus(state, state)
+    SendNUIMessage({action = state and 'open' or 'close', gear = equipped, slots = Config.GearSlots, pos = Config.PanelPosition})
+end
+
+RegisterNUICallback('equip', function(data, cb)
+    TriggerServerEvent('gear_system:equip', data.slot, data.item)
+    cb(true)
+end)
+
+RegisterNUICallback('unequip', function(data, cb)
+    TriggerServerEvent('gear_system:unequip', data.slot)
+    cb(true)
+end)
+
+RegisterNUICallback('close', function(_, cb)
+    toggleUI(false)
+    cb(true)
+end)
+
+RegisterCommand('gear', function()
+    toggleUI(true)
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res == GetCurrentResourceName() and uiOpen then
+        SetNuiFocus(false, false)
+    end
+end)
+
+RegisterNetEvent('ox_inventory:openInventory', function()
+    toggleUI(true)
+end)
+
+RegisterNetEvent('ox_inventory:closeInventory', function()
+    toggleUI(false)
+end)

--- a/gear_system/config.lua
+++ b/gear_system/config.lua
@@ -1,0 +1,110 @@
+Config = {}
+
+-- Framework selection: 'auto', 'esx', or 'qbcore'
+-- When set to 'auto', the script will attempt to detect which
+-- framework is running by checking common resources.
+Config.Framework = 'auto'
+
+-- If you use ox_inventory with ESX/QBCore set this to true to use its
+-- add/remove item exports when equipping gear.
+Config.UseOxInventory = true
+
+-- Enable debug prints in the server/clientside consoles.
+Config.Debug = false
+
+-- UI position for the gear panel (CSS top/left in pixels)
+Config.PanelPosition = {
+    top = 200,
+    left = 50
+}
+
+-- Gear slots available for players. Each entry defines the slot name,
+-- the label displayed in the UI, and which inventory items are allowed
+-- to be equipped in that slot.
+Config.GearSlots = {
+    helmet = { label = 'Helmet', allowedItems = { 'military_helmet', 'iron_helmet' } },
+    chest = { label = 'Armor', allowedItems = { 'kevlar_vest', 'leather_armor' } },
+    pants = { label = 'Pants', allowedItems = { 'combat_pants', 'jeans' } },
+    gloves = { label = 'Gloves', allowedItems = { 'tactical_gloves' } },
+    boots = { label = 'Boots', allowedItems = { 'army_boots', 'leather_boots' } },
+    ring1 = { label = 'Ring (L)', allowedItems = { 'ring_of_fire', 'ring_of_life' } },
+    ring2 = { label = 'Ring (R)', allowedItems = { 'ring_of_power' } },
+    backpack = { label = 'Backpack', allowedItems = { 'hiking_pack', 'military_pack' } },
+    weaponmod = { label = 'Weapon Mod', allowedItems = { 'laser_sight', 'scope_mod' } }
+}
+
+-- Gear items with their stat bonuses. Each item must specify the slot it fits
+-- into, a UI label, optional rarity, and the stats it grants when equipped.
+Config.EquipmentItems = {
+    military_helmet = {
+        slot = 'helmet',
+        label = 'Military Helmet',
+        rarity = 'rare',
+        stats = {
+            maxHealth = { type = 'flat', value = 20 },
+            critChance = { type = 'percent', value = 0.05 }
+        }
+    },
+    ring_of_fire = {
+        slot = 'ring1',
+        label = 'Ring of Fire',
+        rarity = 'epic',
+        stats = {
+            damagePercent = { type = 'percent', value = 0.15 },
+            staminaRecovery = { type = 'flat', value = 5 }
+        }
+    },
+    kevlar_vest = {
+        slot = 'chest',
+        label = 'Kevlar Vest',
+        rarity = 'uncommon',
+        stats = {
+            maxArmor = { type = 'flat', value = 50 }
+        }
+    }
+}
+
+-- Stat bonuses granted by equipping items. All values are additive.
+-- maxHealth and maxArmor modify the player's maximum health/armor.
+-- critChance and critDamage increase critical hit stats.
+-- damageFlat adds flat damage, damagePercent is a multiplier.
+-- speedPercent increases running speed, staminaRecovery affects
+-- regen rate, maxStamina increases stamina pool and meleeDamage
+-- scales unarmed/melee damage.
+Config.ItemStats = {
+    military_helmet = {
+        maxHealth = 20,
+        critChance = 0.05,
+        meleeDamage = 0.1
+    },
+    ring_of_fire = {
+        damagePercent = 0.15,
+        staminaRecovery = 5
+    },
+    kevlar_vest = {
+        maxArmor = 50
+    }
+}
+
+-- Scaling applied to stats before being given to the player.
+-- Useful if your base numbers need adjusting without editing
+-- each item individually.
+Config.StatScaling = {
+    maxHealth = 1.0,
+    maxArmor = 1.0,
+    critChance = 1.0,
+    critDamage = 1.0,
+    damageFlat = 1.0,
+    damagePercent = 1.0,
+    speedPercent = 1.0,
+    staminaRecovery = 1.0,
+    maxStamina = 1.0,
+    meleeDamage = 1.0
+}
+
+-- Utility function for debug printing
+function Debug(...)
+    if Config.Debug then
+        print('[GearSystem]', ...)
+    end
+end

--- a/gear_system/fxmanifest.lua
+++ b/gear_system/fxmanifest.lua
@@ -1,0 +1,26 @@
+fx_version 'cerulean'
+lua54 'yes'
+game 'gta5'
+
+name 'gear_system'
+author 'Generated'
+
+ui_page 'ui/index.html'
+
+files {
+    'ui/index.html',
+    'ui/style.css',
+    'ui/script.js'
+}
+
+shared_scripts {
+    'config.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}

--- a/gear_system/server.lua
+++ b/gear_system/server.lua
@@ -1,0 +1,179 @@
+local GearData = {}
+local PlayerStats = {}
+local framework = {}
+
+local function loadData()
+    local data = LoadResourceFile(GetCurrentResourceName(), 'gear_data.json')
+    if data then
+        GearData = json.decode(data)
+    end
+end
+
+local function saveData()
+    SaveResourceFile(GetCurrentResourceName(), 'gear_data.json', json.encode(GearData), -1)
+end
+
+local function detectFramework()
+    if Config.Framework ~= 'auto' then return Config.Framework end
+    if GetResourceState('es_extended') ~= 'missing' then return 'esx' end
+    if GetResourceState('qb-core') ~= 'missing' then return 'qbcore' end
+    return nil
+end
+
+local function initFramework()
+    framework.name = detectFramework()
+    if framework.name == 'esx' then
+        framework.obj = exports['es_extended']:getSharedObject()
+        framework.getPlayer = function(src) return framework.obj.GetPlayerFromId(src) end
+        framework.identifier = function(player) return player.identifier end
+        framework.addItem = function(player, name)
+            player.addInventoryItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.getInventoryItem(name)
+            if item.count < 1 then return false end
+            player.removeInventoryItem(name, 1)
+            return true
+        end
+    elseif framework.name == 'qbcore' then
+        framework.obj = exports['qb-core']:GetCoreObject()
+        framework.getPlayer = function(src) return framework.obj.Functions.GetPlayer(src) end
+        framework.identifier = function(player) return player.PlayerData.citizenid end
+        framework.addItem = function(player, name)
+            player.Functions.AddItem(name, 1)
+        end
+        framework.removeItem = function(player, name)
+            local item = player.Functions.GetItemByName(name)
+            if not item or item.amount < 1 then return false end
+            player.Functions.RemoveItem(name, 1)
+            return true
+        end
+    end
+end
+
+local function getIdentifier(src)
+    local player = framework.getPlayer(src)
+    if not player then return nil end
+    return framework.identifier(player)
+end
+
+local function giveItem(src, name)
+    if Config.UseOxInventory then
+        exports.ox_inventory:AddItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then framework.addItem(player, name) end
+    end
+end
+
+local function takeItem(src, name)
+    if Config.UseOxInventory then
+        return exports.ox_inventory:RemoveItem(src, name, 1)
+    else
+        local player = framework.getPlayer(src)
+        if player then
+            return framework.removeItem(player, name)
+        end
+    end
+    return false
+end
+
+local function calculateStats(equipped)
+    local stats = {}
+    for slot, item in pairs(equipped) do
+        local s = Config.ItemStats[item]
+        if s then
+            for stat, val in pairs(s) do
+                stats[stat] = (stats[stat] or 0) + (val * (Config.StatScaling[stat] or 1))
+            end
+        end
+    end
+    return stats
+end
+
+local function updatePlayerStats(src)
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local equipped = GearData[identifier] or {}
+    local stats = calculateStats(equipped)
+    PlayerStats[src] = stats
+    TriggerClientEvent('gear_system:applyStats', src, stats)
+    TriggerClientEvent('gear_system:setGear', src, equipped)
+    TriggerEvent('gear_system:statsUpdated', src, stats)
+end
+
+RegisterNetEvent('gear_system:equip', function(slot, item)
+    local src = source
+    if not Config.GearSlots[slot] then return end
+    if not item then return end
+
+    local allowed = false
+    for _, v in pairs(Config.GearSlots[slot].allowedItems) do
+        if v == item then allowed = true break end
+    end
+    if not allowed then return end
+
+    if not takeItem(src, item) then return end
+
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+    GearData[identifier] = GearData[identifier] or {}
+
+    local old = GearData[identifier][slot]
+    if old then
+        giveItem(src, old)
+    end
+
+    GearData[identifier][slot] = item
+    saveData()
+    updatePlayerStats(src)
+end)
+
+RegisterNetEvent('gear_system:unequip', function(slot)
+    local src = source
+    if not Config.GearSlots[slot] then return end
+    local identifier = getIdentifier(src)
+    if not identifier then return end
+
+    local item = GearData[identifier] and GearData[identifier][slot]
+    if item then
+        giveItem(src, item)
+        GearData[identifier][slot] = nil
+        saveData()
+        updatePlayerStats(src)
+    end
+end)
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    PlayerStats[src] = nil
+end)
+
+exports('GetPlayerStats', function(src)
+    return PlayerStats[src] or {}
+end)
+
+AddEventHandler('onResourceStart', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    initFramework()
+    loadData()
+end)
+
+AddEventHandler('onResourceStop', function(res)
+    if res ~= GetCurrentResourceName() then return end
+    saveData()
+end)
+
+-- framework player loaded events
+RegisterNetEvent('esx:playerLoaded', function(id)
+    if framework.name ~= 'esx' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)
+
+RegisterNetEvent('QBCore:Server:PlayerLoaded', function(id)
+    if framework.name ~= 'qbcore' then return end
+    local src = id or source
+    updatePlayerStats(src)
+end)

--- a/gear_system/ui/index.html
+++ b/gear_system/ui/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Gear System</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<div id="gear-panel" class="hidden">
+    <div id="close">X</div>
+    <div id="slots"></div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/gear_system/ui/script.js
+++ b/gear_system/ui/script.js
@@ -1,0 +1,83 @@
+let gear = {};
+let slots = {};
+
+function createSlots() {
+    const container = document.getElementById('slots');
+    container.innerHTML = '';
+    Object.entries(slots).forEach(([name, cfg]) => {
+        const div = document.createElement('div');
+        div.className = 'slot';
+        div.dataset.slot = name;
+        div.textContent = cfg.label;
+        div.addEventListener('dragover', e => {
+            e.preventDefault();
+            div.classList.add('dragover');
+        });
+        div.addEventListener('dragleave', () => div.classList.remove('dragover'));
+        div.addEventListener('drop', e => {
+            e.preventDefault();
+            div.classList.remove('dragover');
+            const item = e.dataTransfer.getData('item');
+            if (item) sendEquip(name, item);
+        });
+        container.appendChild(div);
+    });
+}
+
+function renderGear() {
+    document.querySelectorAll('.slot').forEach(s => {
+        const slot = s.dataset.slot;
+        s.innerHTML = `<strong>${slots[slot].label}</strong>`;
+        const item = gear[slot];
+        if (item) {
+            const el = document.createElement('div');
+            el.className = 'item';
+            el.textContent = item;
+            el.draggable = true;
+            el.addEventListener('dragstart', e => {
+                e.dataTransfer.setData('slot', slot);
+                e.dataTransfer.setData('item', item);
+            });
+            s.appendChild(el);
+        }
+    });
+}
+
+function sendEquip(slot, item) {
+    fetch(`https://gear_system/equip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot, item})
+    });
+}
+
+function sendUnequip(slot) {
+    fetch(`https://gear_system/unequip`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({slot})
+    });
+}
+
+document.getElementById('close').addEventListener('click', () => {
+    fetch('https://gear_system/close', {method: 'POST'});
+});
+
+window.addEventListener('message', event => {
+    const data = event.data;
+    if (data.action === 'open') {
+        gear = data.gear || {};
+        slots = data.slots || {};
+        createSlots();
+        renderGear();
+        const panel = document.getElementById('gear-panel');
+        panel.style.top = data.pos.top + 'px';
+        panel.style.left = data.pos.left + 'px';
+        panel.classList.add('show');
+    } else if (data.action === 'close') {
+        document.getElementById('gear-panel').classList.remove('show');
+    } else if (data.action === 'setGear') {
+        gear = data.gear || {};
+        renderGear();
+    }
+});

--- a/gear_system/ui/style.css
+++ b/gear_system/ui/style.css
@@ -1,0 +1,35 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+#gear-panel {
+    position: absolute;
+    background: rgba(30, 30, 30, 0.9);
+    padding: 10px;
+    width: 200px;
+    color: #fff;
+    display: none;
+}
+#gear-panel.show {
+    display: block;
+}
+#close {
+    cursor: pointer;
+    text-align: right;
+}
+.slot {
+    border: 1px solid #555;
+    padding: 5px;
+    margin: 5px 0;
+    background: #222;
+    min-height: 30px;
+}
+.slot.dragover {
+    background: #444;
+}
+.item {
+    background: #555;
+    margin: 2px;
+    padding: 2px 4px;
+    cursor: move;
+}


### PR DESCRIPTION
## Summary
- add a standalone `gear_system` resource
- implement ESX/QBCore framework detection
- provide drag-and-drop equipment UI and stat bonuses
- sample configuration with example items
- restore EquipmentItems table in config

## Testing
- `luac -p gear_system/server.lua`
- `luac -p gear_system/client.lua`
- `lua -e "assert(loadfile('gear_system/config.lua'))"`
