### PR TITLE
Add standalone gear equipment system

### DIFF
--- a/gear_system/client.lua
+++ b/gear_system/client.lua
@@ -1,0 +1,86 @@
+local gear = {}
+local uiOpen = false
+
+local function notify(msg)
+    if lib and lib.notify then
+        lib.notify({ description = msg })
+    else
+        TriggerEvent('chat:addMessage', { args = { msg } })
+    end
+end
+
+local function toggleUI(state)
+    SetNuiFocus(state, state)
+    SetNuiFocusKeepInput(state)
+    SendNUIMessage({ action = 'setVisible', state = state, slots = gear, config = Config })
+    uiOpen = state
+end
+
+RegisterNUICallback('close', function(_, cb)
+    toggleUI(false)
+    cb(true)
+end)
+
+RegisterNUICallback('equipItem', function(data, cb)
+    TriggerServerEvent('gear:serverEquip', data)
+    cb(true)
+end)
+
+RegisterNUICallback('unequipItem', function(data, cb)
+    TriggerServerEvent('gear:serverUnequip', data)
+    cb(true)
+end)
+
+RegisterNetEvent('gear:clientUpdate', function(data)
+    gear = data
+    if uiOpen then
+        SendNUIMessage({ action = 'update', slots = gear })
+    end
+end)
+
+local function openCommand()
+    if uiOpen then
+        toggleUI(false)
+    else
+        TriggerServerEvent('gear:serverRequest')
+        toggleUI(true)
+    end
+end
+
+if Config.Features.commandAccess then
+    RegisterCommand('gear', openCommand)
+    if Config.DebugTools and Config.DebugTools.debugCommandEnabled then
+        RegisterCommand('gearstatus', function()
+            TriggerServerEvent('gear:serverStatus')
+        end)
+    end
+    RegisterCommand('gearreset', function()
+        TriggerServerEvent('gear:serverReset')
+    end)
+    RegisterCommand('gearreload', function()
+        TriggerServerEvent('gear:serverReload')
+    end, true)
+end
+
+RegisterNetEvent('ox_inventory:openInventory', function()
+    if Config.Features.openWithInventory and not uiOpen then
+        openCommand()
+    end
+end)
+
+-- When resource starts, request gear if persist enabled
+AddEventHandler('onClientResourceStart', function(res)
+    if res == GetCurrentResourceName() and Config.Features.persistGear then
+        TriggerServerEvent('gear:serverRequest')
+    end
+end)
+
+RegisterNetEvent('gear:applyStats', function(stats)
+    local ped = PlayerPedId()
+    if stats.maxHealth then
+        SetEntityMaxHealth(ped, 100 + stats.maxHealth)
+    end
+    if stats.maxArmor then
+        SetPedArmour(ped, stats.maxArmor)
+    end
+end)

--- a/gear_system/config.lua
+++ b/gear_system/config.lua
@@ -1,0 +1,290 @@
+--[[
+==========================================================
+ FiveM Equipment Gear System - Configuration File
+==========================================================
+
+This file controls every aspect of the gear system. Each
+section is fully documented so you can customise behaviour
+without touching any Lua code.
+==========================================================
+]]
+
+Config = {}
+
+-- Framework selection: 'auto', 'esx', 'qbcore' or 'none'.
+-- When set to 'auto' the script will attempt to detect
+-- ESX or QBCore automatically.
+Config.Framework = 'auto'
+
+-- Inventory system used to give and remove items.
+-- 'ox' = ox_inventory (recommended)
+-- 'qb' = qb-inventory
+Config.InventorySystem = 'ox'
+
+-- Print which inventory bridge is used when moving items
+-- between inventory and gear slots.
+Config.InventoryBridgeDebug = false
+
+-- Enable general debug prints to console.
+Config.Debug = false
+
+---------------------------------------------------------------------
+-- GEAR SLOTS
+---------------------------------------------------------------------
+-- Define the available equipment slots. The order here will be the
+-- order shown in the UI. Set showInUI to false if you wish to hide
+-- a slot from the gear panel.
+Config.GearSlots = {
+    head     = { label = 'Head',     allowMultiple = false, showInUI = true },
+    chest    = { label = 'Chest',    allowMultiple = false, showInUI = true },
+    legs     = { label = 'Legs',     allowMultiple = false, showInUI = true },
+    feet     = { label = 'Feet',     allowMultiple = false, showInUI = true },
+    hands    = { label = 'Hands',    allowMultiple = false, showInUI = true },
+    neck     = { label = 'Neck',     allowMultiple = false, showInUI = true },
+    ring1    = { label = 'Ring 1',   allowMultiple = false, showInUI = true },
+    ring2    = { label = 'Ring 2',   allowMultiple = false, showInUI = true },
+    trinket1 = { label = 'Trinket',  allowMultiple = false, showInUI = true },
+    trinket2 = { label = 'Trinket 2',allowMultiple = false, showInUI = true }
+}
+
+---------------------------------------------------------------------
+-- EQUIPMENT ITEMS
+---------------------------------------------------------------------
+-- Each item here represents an inventory item that can be equipped.
+-- slot  : Which gear slot it fits into
+-- label : Display name in the UI
+-- rarity: One of the keys defined in Config.RarityTiers
+-- stats : Table of stat bonuses granted when equipped
+Config.EquipmentItems = {
+    military_helmet = {
+        slot = 'head',
+        label = 'Military Helmet',
+        rarity = 'uncommon',
+        stats = {
+            maxHealth  = { type = 'flat',    value = 25 },
+            critChance = { type = 'percent', value = 0.10 }
+        }
+    },
+
+    ring_of_fire = {
+        slot = 'ring1',
+        label = 'Ring of Fire',
+        rarity = 'rare',
+        stats = {
+            damagePercent   = { type = 'percent', value = 0.15 },
+            staminaRecovery = { type = 'flat',    value = 5 }
+        }
+    },
+
+    kevlar_vest = {
+        slot = 'chest',
+        label = 'Kevlar Vest',
+        rarity = 'common',
+        stats = {
+            maxArmor = { type = 'flat', value = 50 }
+        }
+    },
+
+    iron_greaves = {
+        slot = 'legs',
+        label = 'Iron Greaves',
+        rarity = 'uncommon',
+        stats = {
+            maxStamina = { type = 'flat', value = 20 }
+        }
+    },
+
+    ring_of_shadows = {
+        slot = 'ring2',
+        label = 'Ring of Shadows',
+        rarity = 'epic',
+        stats = {
+            critChance = { type = 'percent', value = 0.12 },
+            critDamage = { type = 'percent', value = 0.30 }
+        }
+    },
+
+    trinket_mystic_core = {
+        slot = 'trinket1',
+        label = 'Mystic Core',
+        rarity = 'rare',
+        stats = {
+            meleeDamage = { type = 'percent', value = 0.15 },
+            flatDamage  = { type = 'flat',    value = 3 }
+        }
+    },
+
+    silver_amulet = {
+        slot = 'neck',
+        label = 'Silver Amulet',
+        rarity = 'uncommon',
+        stats = {
+            speedPercent = { type = 'percent', value = 0.08 }
+        }
+    },
+
+    leather_boots = {
+        slot = 'feet',
+        label = 'Leather Boots',
+        rarity = 'common',
+        stats = {
+            speedPercent    = { type = 'percent', value = 0.03 },
+            staminaRecovery = { type = 'flat',    value = 2 }
+        }
+    },
+
+    powered_gloves = {
+        slot = 'hands',
+        label = 'Powered Gloves',
+        rarity = 'epic',
+        stats = {
+            meleeDamage     = { type = 'percent', value = 0.25 },
+            staminaRecovery = { type = 'flat',    value = 4 }
+        }
+    },
+
+    ember_trinket = {
+        slot = 'trinket2',
+        label = 'Ember Trinket',
+        rarity = 'legendary',
+        stats = {
+            damagePercent = { type = 'percent', value = 0.25 },
+            critDamage    = { type = 'percent', value = 0.35 }
+        }
+    }
+}
+
+---------------------------------------------------------------------
+-- RARITY TIERS
+---------------------------------------------------------------------
+-- Rarity tiers modify item colouring in the UI and provide a
+-- multiplier applied to the item's stats.
+Config.RarityTiers = {
+    common = {
+        label = 'Common',
+        color = '#808080',    -- grey
+        statMultiplier = 1.0
+    },
+    uncommon = {
+        label = 'Uncommon',
+        color = '#00ff00',    -- green
+        statMultiplier = 1.1
+    },
+    rare = {
+        label = 'Rare',
+        color = '#007bff',    -- blue
+        statMultiplier = 1.25
+    },
+    epic = {
+        label = 'Epic',
+        color = '#a64ca6',    -- purple
+        statMultiplier = 1.4
+    },
+    legendary = {
+        label = 'Legendary',
+        color = '#ff4444',    -- red
+        statMultiplier = 1.6
+    }
+}
+
+---------------------------------------------------------------------
+-- UI SETTINGS
+---------------------------------------------------------------------
+Config.UI = {
+    backgroundColor = '#1a1a1a',
+    textColor       = '#ffffff',
+    borderColor     = '#3e8ed0',
+    highlightColor  = '#00ff00',
+    font            = 'Arial',
+    fontSize        = 14,
+    iconSize        = 48,
+
+    hoverPreview = {
+        enabled    = true,
+        background = '#111111',
+        textColor  = '#ffffff',
+        position   = 'right' -- 'right' or 'below'
+    },
+
+    equipAnimation = {
+        enabled  = true,
+        type     = 'glow', -- 'none', 'pulse', 'glow', 'slide'
+        color    = '#00ff88',
+        duration = 300
+    },
+
+    dragPreview = {
+        enabled            = true,
+        showStatDifference = true
+    },
+
+    lockedSlotTooltip = {
+        enabled = true,
+        text    = 'Requires level {{level}} or job: {{job}}'
+    },
+
+    statOverlay = {
+        enabled   = true,
+        style     = 'minimal',
+        showStats = { 'maxHealth', 'maxArmor', 'flatDamage', 'critChance' }
+    },
+
+    toggleButton = {
+        enabled  = true,
+        icon     = '\xF0\x9F\x9B\xA1', -- shield emoji
+        position = { bottom = 30, left = 20 }
+    }
+}
+
+---------------------------------------------------------------------
+-- SCRIPT FEATURE TOGGLES
+---------------------------------------------------------------------
+Config.Features = {
+    allowStatEffects        = true,  -- If false, gear gives no bonuses
+    openWithInventory       = true,  -- Open panel when inventory opens
+    commandAccess           = true,  -- Enables /gear commands
+    persistGear             = true,  -- Save gear between sessions
+    showStatPreviewOnHover  = true,  -- Show stat effects on hover
+    showTooltipDescriptions = true   -- Show slot help text in UI
+}
+
+---------------------------------------------------------------------
+-- DEBUG TOOLS
+---------------------------------------------------------------------
+Config.DebugTools = {
+    enableVerboseLogs      = false,
+    logStatCalculations    = false,
+    logItemLookup          = false,
+    showInvalidItems       = true,
+    showInvalidSlots       = true,
+    printStatTotalsOnEquip = false,
+    notifyOnEquip          = false,
+    debugCommandEnabled    = true
+}
+
+---------------------------------------------------------------------
+-- STAT SCALING
+---------------------------------------------------------------------
+-- Global multipliers applied to all item stats when equipped.
+Config.StatScaling = {
+    maxHealth       = 1.0,
+    maxArmor        = 1.0,
+    critChance      = 1.0,
+    critDamage      = 1.0,
+    flatDamage      = 1.0,
+    damagePercent   = 1.0,
+    speedPercent    = 1.0,
+    staminaRecovery = 1.0,
+    maxStamina      = 1.0,
+    meleeDamage     = 1.0
+}
+
+---------------------------------------------------------------------
+-- UTILITY DEBUG PRINT FUNCTION
+---------------------------------------------------------------------
+function Debug(...)
+    if Config.Debug or (Config.DebugTools and Config.DebugTools.enableVerboseLogs) then
+        print('[GearSystem]', ...)
+    end
+end
+

--- a/gear_system/fxmanifest.lua
+++ b/gear_system/fxmanifest.lua
@@ -1,0 +1,20 @@
+fx_version 'cerulean'
+game 'gta5'
+
+author 'Codex Gear System'
+description 'Standalone equipment/gear system with stat bonuses'
+
+shared_script 'config.lua'
+client_script 'client.lua'
+server_script 'server.lua'
+server_script 'inventory_bridge.lua'
+
+ui_page 'html/ui.html'
+
+files {
+    'html/ui.html',
+    'html/style.css',
+    'html/app.js'
+}
+
+lua54 'yes'

--- a/gear_system/html/app.js
+++ b/gear_system/html/app.js
@@ -1,0 +1,57 @@
+let visible = false;
+let Config = {};
+let slots = {};
+
+window.addEventListener('message', (event) => {
+    const data = event.data;
+    if (data.action === 'setVisible') {
+        visible = data.state;
+        document.getElementById('gearPanel').classList.toggle('visible', visible);
+        if (data.config) { Config = data.config; applyConfig(data.config); }
+        if (data.slots) loadSlots(data.slots);
+    } else if (data.action === 'update') {
+        loadSlots(data.slots);
+    }
+});
+
+document.getElementById('closeBtn').addEventListener('click', () => {
+    fetch(`https://${GetParentResourceName()}/close`, { method: 'POST', body: '{}' });
+});
+
+function applyConfig(cfg) {
+    document.documentElement.style.setProperty('--bg', cfg.backgroundColor);
+    document.documentElement.style.setProperty('--text', cfg.textColor);
+    document.documentElement.style.setProperty('--border', cfg.borderColor);
+    document.documentElement.style.setProperty('--highlight', cfg.highlightColor);
+}
+
+function loadSlots(data) {
+    slots = data;
+    const container = document.getElementById('slots');
+    container.innerHTML = '';
+    Object.keys(cfgSlots()).forEach((slot) => {
+        const div = document.createElement('div');
+        div.className = 'slot';
+        div.dataset.slot = slot;
+        div.innerText = data[slot] || '';
+        div.addEventListener('dragover', allowDrop);
+        div.addEventListener('drop', onDrop);
+        container.appendChild(div);
+    });
+}
+
+function cfgSlots() { return Config.GearSlots || {}; }
+
+function allowDrop(e) { e.preventDefault(); }
+
+function onDrop(e) {
+    e.preventDefault();
+    const item = e.dataTransfer.getData('item');
+    const slot = this.dataset.slot;
+    fetch(`https://${GetParentResourceName()}/equipItem`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ item: item, slot: slot })
+    });
+    this.classList.add('glow');
+}

--- a/gear_system/html/style.css
+++ b/gear_system/html/style.css
@@ -1,0 +1,45 @@
+:root {
+    --bg: #1a1a1a;
+    --text: #fff;
+    --border: #3e8ed0;
+    --highlight: #00ff00;
+    --font: Arial, sans-serif;
+}
+body {
+    margin: 0;
+    padding: 0;
+    font-family: var(--font);
+    color: var(--text);
+}
+#gearPanel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--bg);
+    border: 2px solid var(--border);
+    padding: 10px;
+    display: none;
+}
+#gearPanel.visible { display: block; }
+#slots {
+    display: grid;
+    grid-template-columns: repeat(2, 80px);
+    grid-gap: 6px;
+}
+.slot {
+    width: 80px;
+    height: 80px;
+    border: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.slot.glow {
+    animation: glow 0.3s ease-out;
+}
+@keyframes glow {
+    from { box-shadow: 0 0 10px var(--highlight); }
+    to { box-shadow: none; }
+}
+.hidden { display: none; }

--- a/gear_system/html/ui.html
+++ b/gear_system/html/ui.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Gear System</title>
+</head>
+<body>
+    <div id="gearPanel" class="hidden">
+        <div id="slots"></div>
+        <button id="closeBtn">X</button>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/gear_system/inventory_bridge.lua
+++ b/gear_system/inventory_bridge.lua
@@ -1,0 +1,21 @@
+local Inventory = {}
+
+function Inventory.RemoveItem(source, item, count, metadata)
+    if Config.InventorySystem == 'ox' then
+        return exports.ox_inventory:RemoveItem(source, item, count, metadata)
+    elseif Config.InventorySystem == 'qb' then
+        return exports['qb-inventory']:RemoveItem(source, item, count, metadata)
+    end
+    return false
+end
+
+function Inventory.AddItem(source, item, count, metadata)
+    if Config.InventorySystem == 'ox' then
+        return exports.ox_inventory:AddItem(source, item, count, metadata)
+    elseif Config.InventorySystem == 'qb' then
+        return exports['qb-inventory']:AddItem(source, item, count, metadata)
+    end
+    return false
+end
+
+return Inventory

--- a/gear_system/server.lua
+++ b/gear_system/server.lua
@@ -1,0 +1,157 @@
+local Inventory = require 'inventory_bridge'
+local gearPlayers = {}
+
+local function getFramework()
+    if Config.Framework == 'esx' then return 'esx' end
+    if Config.Framework == 'qbcore' then return 'qbcore' end
+    if Config.Framework == 'auto' then
+        if ESX then return 'esx' end
+        if QBCore then return 'qbcore' end
+    end
+    return nil
+end
+
+local function getIdentifier(source)
+    local fw = getFramework()
+    if fw == 'esx' then
+        local x = ESX.GetPlayerFromId(source)
+        return x and x.identifier
+    elseif fw == 'qbcore' then
+        local p = QBCore.Functions.GetPlayer(source)
+        return p and p.PlayerData.citizenid
+    else
+        local id = GetPlayerIdentifier(source, 0)
+        return id
+    end
+end
+
+local function saveGear(id, data)
+    if not Config.Features.persistGear then return end
+    if not id then return end
+    SetResourceKvp('gear_' .. id, json.encode(data))
+end
+
+local function loadGear(id)
+    if not Config.Features.persistGear then return {} end
+    if not id then return {} end
+    local data = GetResourceKvpString('gear_' .. id)
+    return data and json.decode(data) or {}
+end
+
+local function calculateStats(gear)
+    local totals = {}
+    for slot,item in pairs(gear) do
+        local def = Config.EquipmentItems[item]
+        if def then
+            local rarity = Config.RarityTiers[def.rarity]
+            local mult = rarity and rarity.statMultiplier or 1.0
+            for stat,info in pairs(def.stats) do
+                local val = info.value * mult * (Config.StatScaling[stat] or 1.0)
+                totals[stat] = (totals[stat] or 0) + val
+            end
+        end
+    end
+    return totals
+end
+
+local function applyStats(source, stats)
+    if not Config.Features.allowStatEffects then return end
+    TriggerClientEvent('gear:applyStats', source, stats)
+end
+
+local function sendUpdate(src)
+    TriggerClientEvent('gear:clientUpdate', src, gearPlayers[src] or {})
+    applyStats(src, calculateStats(gearPlayers[src] or {}))
+end
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    local id = getIdentifier(src)
+    if gearPlayers[src] then
+        saveGear(id, gearPlayers[src])
+        gearPlayers[src] = nil
+    end
+end)
+
+AddEventHandler('playerJoining', function()
+    local src = source
+    local id = getIdentifier(src)
+    gearPlayers[src] = loadGear(id)
+end)
+
+RegisterServerEvent('gear:serverRequest', function()
+    local src = source
+    if not gearPlayers[src] then
+        local id = getIdentifier(src)
+        gearPlayers[src] = loadGear(id)
+    end
+    sendUpdate(src)
+end)
+
+RegisterServerEvent('gear:serverEquip', function(data)
+    local src = source
+    local item = data.item
+    local slot = data.slot
+    local def = Config.EquipmentItems[item]
+    if not def then
+        if Config.DebugTools.showInvalidItems then
+            print('[GearSystem] Invalid item: ' .. tostring(item))
+        end
+        return
+    end
+    if def.slot ~= slot then
+        if Config.DebugTools.showInvalidSlots then
+            print('[GearSystem] Item ' .. item .. ' does not fit slot ' .. slot)
+        end
+        return
+    end
+    if not gearPlayers[src] then gearPlayers[src] = {} end
+    if gearPlayers[src][slot] then
+        -- slot occupied
+        Inventory.AddItem(src, gearPlayers[src][slot], 1)
+    end
+    if Inventory.RemoveItem(src, item, 1) then
+        gearPlayers[src][slot] = item
+        sendUpdate(src)
+    else
+        print('[GearSystem] Unable to remove item from inventory: ' .. item)
+    end
+end)
+
+RegisterServerEvent('gear:serverUnequip', function(data)
+    local src = source
+    local slot = data.slot
+    if gearPlayers[src] and gearPlayers[src][slot] then
+        local item = gearPlayers[src][slot]
+        if Inventory.AddItem(src, item, 1) then
+            gearPlayers[src][slot] = nil
+            sendUpdate(src)
+        else
+            print('[GearSystem] Unable to give item back: ' .. item)
+        end
+    end
+end)
+
+RegisterServerEvent('gear:serverReset', function()
+    local src = source
+    if gearPlayers[src] then
+        for slot,item in pairs(gearPlayers[src]) do
+            Inventory.AddItem(src, item, 1)
+        end
+    end
+    gearPlayers[src] = {}
+    sendUpdate(src)
+end)
+
+RegisterServerEvent('gear:serverReload', function()
+    if IsPlayerAceAllowed(source, 'gearsystem.admin') then
+        print('[GearSystem] Reloading config')
+        dofile('config.lua')
+    end
+end)
+
+RegisterServerEvent('gear:serverStatus', function()
+    local src = source
+    local stats = calculateStats(gearPlayers[src] or {})
+    TriggerClientEvent('chat:addMessage', src, { args = { 'Gear Status: ' .. json.encode(stats) } })
+end)


### PR DESCRIPTION
## Summary
- implement new `gear_system` resource
- add configurable gear slots, rarity tiers, items and UI settings
- include drag and drop NUI for equipping items
- support ox_inventory or qb-inventory via bridge
- add server logic to apply stat bonuses, persist gear and provide commands

## Testing
- `luac -p gear_system/config.lua`
- `luac -p gear_system/client.lua`
- `luac -p gear_system/server.lua`
- `luac -p gear_system/inventory_bridge.lua`
